### PR TITLE
[feat] 사원 기본 CRUD 구현

### DIFF
--- a/smerp/src/main/java/com/domino/smerp/client/Client.java
+++ b/smerp/src/main/java/com/domino/smerp/client/Client.java
@@ -1,0 +1,23 @@
+package com.domino.smerp.client;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Client {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long clientId;
+
+    private String name;
+}

--- a/smerp/src/main/java/com/domino/smerp/client/ClientRepository.java
+++ b/smerp/src/main/java/com/domino/smerp/client/ClientRepository.java
@@ -1,0 +1,6 @@
+package com.domino.smerp.client;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClientRepository extends JpaRepository<Client, Long> {
+}

--- a/smerp/src/main/java/com/domino/smerp/user/User.java
+++ b/smerp/src/main/java/com/domino/smerp/user/User.java
@@ -1,0 +1,79 @@
+package com.domino.smerp.user;
+
+import com.domino.smerp.client.Client;
+import com.domino.smerp.user.constants.UserRole;
+import com.domino.smerp.user.dto.request.UpdateUserRequest;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private String phone;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = false, unique = true)
+    private String ssn;
+
+    @Column(nullable = false)
+    private LocalDate hireDate;
+
+    @Column(nullable = true)
+    private LocalDate fireDate;
+
+    @Column(nullable = false, unique = true)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String deptTitle;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id", nullable = true)
+    private Client client;
+
+    public void updateUser(UpdateUserRequest request){
+        if (request.getAddress() != null) this.address = request.getAddress();
+        if (request.getPhone() != null) this.phone = request.getPhone();
+        if (request.getDeptTitle() != null) this.deptTitle = request.getDeptTitle();
+        if (request.getRole() != null) this.role = request.getRole();
+        if (request.getFireDate() != null) this.fireDate = request.getFireDate();
+    }
+}

--- a/smerp/src/main/java/com/domino/smerp/user/UserController.java
+++ b/smerp/src/main/java/com/domino/smerp/user/UserController.java
@@ -1,0 +1,54 @@
+package com.domino.smerp.user;
+
+import com.domino.smerp.user.dto.request.CreateUserRequest;
+import com.domino.smerp.user.dto.request.UpdateUserRequest;
+import com.domino.smerp.user.dto.response.UserListResponse;
+import com.domino.smerp.user.dto.response.UserResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createUser(@RequestBody CreateUserRequest request) {
+        userService.createUser(request);
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<UserListResponse> showAllUsers() {
+        return userService.findAllUsers();
+    }
+
+    @GetMapping("/{userId}")
+    public UserResponse findUserById(@PathVariable Long userId) {
+        return userService.findUserById(userId);
+    }
+
+    @DeleteMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteUser(@PathVariable Long userId) {
+        userService.deleteUser(userId);
+    }
+
+    @PatchMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateUser(@PathVariable Long userId, @RequestBody UpdateUserRequest request) {
+        userService.updateUser(userId, request);
+    }
+}

--- a/smerp/src/main/java/com/domino/smerp/user/UserRepository.java
+++ b/smerp/src/main/java/com/domino/smerp/user/UserRepository.java
@@ -1,0 +1,12 @@
+package com.domino.smerp.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User,Long> {
+    boolean existsByLoginId(String loginId);
+    boolean existsByEmail(String email);
+    boolean existsByPhone(String phone);
+    boolean existsBySsn(String ssn);
+}

--- a/smerp/src/main/java/com/domino/smerp/user/UserService.java
+++ b/smerp/src/main/java/com/domino/smerp/user/UserService.java
@@ -1,0 +1,15 @@
+package com.domino.smerp.user;
+
+import com.domino.smerp.user.dto.request.CreateUserRequest;
+import com.domino.smerp.user.dto.request.UpdateUserRequest;
+import com.domino.smerp.user.dto.response.UserListResponse;
+import com.domino.smerp.user.dto.response.UserResponse;
+import java.util.List;
+
+public interface UserService {
+    void createUser(CreateUserRequest request);
+    List<UserListResponse> findAllUsers();
+    void deleteUser(Long userId);
+    UserResponse findUserById(Long userId);
+    void updateUser(Long userId,UpdateUserRequest request);
+}

--- a/smerp/src/main/java/com/domino/smerp/user/UserServiceImpl.java
+++ b/smerp/src/main/java/com/domino/smerp/user/UserServiceImpl.java
@@ -1,0 +1,121 @@
+package com.domino.smerp.user;
+
+import com.domino.smerp.client.Client;
+import com.domino.smerp.client.ClientRepository;
+import com.domino.smerp.user.constants.UserRole;
+import com.domino.smerp.user.dto.request.CreateUserRequest;
+import com.domino.smerp.user.dto.request.UpdateUserRequest;
+import com.domino.smerp.user.dto.response.UserListResponse;
+import com.domino.smerp.user.dto.response.UserResponse;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+    private final ClientRepository clientRepository;
+
+    @Override
+    @Transactional
+    public void createUser(CreateUserRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new IllegalArgumentException("중복된 이메일");
+        }
+        if (userRepository.existsByPhone(request.getPhone())) {
+            throw new IllegalArgumentException("중복된 전화번호");
+        }
+        if (userRepository.existsByLoginId(request.getLoginId())) {
+            throw new IllegalArgumentException("중복된 아이디");
+        }
+        if (userRepository.existsBySsn(request.getSsn())) {
+            throw new IllegalArgumentException("중복된 주민번호");
+        }
+
+        Client client = null;
+
+        if (request.getClientId() != null) {
+            client = clientRepository.findById(request.getClientId())
+                                     .orElseThrow(
+                                         () -> new IllegalArgumentException("없는 클라이언트"));
+        }
+
+        User user = User.builder()
+                        .name(request.getName())
+                        .email(request.getEmail())
+                        .phone(request.getPhone())
+                        .address(request.getAddress())
+                        .ssn(request.getSsn())
+                        .loginId(request.getLoginId())
+                        .password(request.getPassword())
+                        .hireDate(LocalDate.parse(request.getHireDate()))
+                        .fireDate(
+                            request.getFireDate() != null ? LocalDate.parse(request.getFireDate())
+                                : null)
+                        .deptTitle(request.getDeptTitle())
+                        .role(UserRole.valueOf(request.getRole()))
+                        .client(client)
+                        .build();
+
+        userRepository.save(user);
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UserListResponse> findAllUsers() {
+        List<User> allUser = userRepository.findAll();
+
+        return allUser.stream()
+                      .map(users -> UserListResponse.builder()
+                                                    .name(users.getName())
+                                                    .email(users.getEmail())
+                                                    .address(users.getAddress())
+                                                    .phone(users.getPhone())
+                                                    .deptTitle(users.getDeptTitle())
+                                                    .role(String.valueOf(users.getRole()))
+                                                    .build())
+                      .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void deleteUser(Long UserId) {
+        userRepository.deleteById(UserId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponse findUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                                  .orElseThrow(() -> new IllegalArgumentException("해당유저 없음"));
+
+        Client client = user.getClient();
+
+        return UserResponse.builder()
+                           .userId(user.getUserId())
+                           .name(user.getName())
+                           .email(user.getEmail())
+                           .phone(user.getPhone())
+                           .address(user.getAddress())
+                           .ssn(user.getSsn())
+                           .hireDate(user.getHireDate())
+                           .fireDate(user.getFireDate())
+                           .loginId(user.getLoginId())
+                           .deptTitle(user.getDeptTitle())
+                           .role(user.getRole())
+                           .clientName(client != null ? client.getName() : "거래처 아님")
+                           .build();
+    }
+
+    @Override
+    @Transactional
+    public void updateUser(Long userId,UpdateUserRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("해당유저 없음"));
+        user.updateUser(request);
+    }
+}

--- a/smerp/src/main/java/com/domino/smerp/user/constants/UserRole.java
+++ b/smerp/src/main/java/com/domino/smerp/user/constants/UserRole.java
@@ -1,0 +1,6 @@
+package com.domino.smerp.user.constants;
+
+public enum UserRole {
+    ADMIN,
+    USER
+}

--- a/smerp/src/main/java/com/domino/smerp/user/dto/request/CreateUserRequest.java
+++ b/smerp/src/main/java/com/domino/smerp/user/dto/request/CreateUserRequest.java
@@ -1,0 +1,23 @@
+package com.domino.smerp.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class CreateUserRequest {
+    private final String name;
+    private final String email;
+    private final String phone;
+    private final String address;
+    private final String ssn;
+    private final String loginId;
+    private final String password;
+    private final String hireDate;
+    private final String fireDate;
+    private final String deptTitle;
+    private final String role;
+    private final Long clientId;
+}

--- a/smerp/src/main/java/com/domino/smerp/user/dto/request/UpdateUserRequest.java
+++ b/smerp/src/main/java/com/domino/smerp/user/dto/request/UpdateUserRequest.java
@@ -1,0 +1,18 @@
+package com.domino.smerp.user.dto.request;
+
+import com.domino.smerp.user.constants.UserRole;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class UpdateUserRequest {
+    private final String address;
+    private final String phone;
+    private final String deptTitle;
+    private final UserRole role;
+    private final LocalDate fireDate;
+}

--- a/smerp/src/main/java/com/domino/smerp/user/dto/response/UserListResponse.java
+++ b/smerp/src/main/java/com/domino/smerp/user/dto/response/UserListResponse.java
@@ -1,0 +1,17 @@
+package com.domino.smerp.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class UserListResponse {
+    private final String name;
+    private final String email;
+    private final String phone;
+    private final String address;
+    private final String deptTitle;
+    private final String role;
+}

--- a/smerp/src/main/java/com/domino/smerp/user/dto/response/UserResponse.java
+++ b/smerp/src/main/java/com/domino/smerp/user/dto/response/UserResponse.java
@@ -1,0 +1,26 @@
+package com.domino.smerp.user.dto.response;
+
+import com.domino.smerp.user.constants.UserRole;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class UserResponse {
+    private final Long userId;
+    private final String name;
+    private final String email;
+    private final String phone;
+    private final String address;
+    private final String ssn;
+    private final LocalDate hireDate;
+    private final LocalDate fireDate;
+    private final String loginId;
+    private final String deptTitle;
+    private final UserRole role;
+    private final String clientName;
+
+}


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 회원의 기본 CRUD 기능 구현했습니다.

## ✨ 변경 사항 (Changes)
POST http://localhost:8080/api/v1/users 로 사원 생성
GET http://localhost:8080/api/v1/users 으로 전체 사원 조회
GET http://localhost:8080/api/v1/users/1  userId 값으로 특정 사원 조회
PATCH http://localhost:8080/api/v1/users/1 특정 사원 정보 수정
DELETE http://localhost:8080/api/v1/users/1 특정 사원 삭제

## 🔀 작업한 브랜치 (Working Branch)
> feature/user/crud

## #️⃣ 관련 이슈 (Issue)
- #1 

## ℹ️ 추가 설명 (Additional Info)
> 
```java
    public void updateUser(UpdateUserRequest request){
        if (request.getAddress() != null) this.address = request.getAddress();
        if (request.getPhone() != null) this.phone = request.getPhone();
        if (request.getDeptTitle() != null) this.deptTitle = request.getDeptTitle();
        if (request.getRole() != null) this.role = request.getRole();
        if (request.getFireDate() != null) this.fireDate = request.getFireDate();
    }
```

  Setter를 사용하지 않기 때문에 엔티티에 메소드를 만들어서 작업했습니다.
