### PR TITLE
[feat] 거래처명, 사업자 번호 검색 구현

### DIFF
--- a/smerp/src/main/java/com/domino/smerp/client/ClientController.java
+++ b/smerp/src/main/java/com/domino/smerp/client/ClientController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,9 +41,9 @@ public class ClientController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public List<ClientListResponse> findAllClients() {
+    public List<ClientListResponse> findAllClients(@RequestParam(required = false) final String companyName, @RequestParam(required = false) final String businessNumber) {
 
-        return clientService.findAllClients();
+        return clientService.findAllClients(companyName,businessNumber);
     }
 
     @GetMapping("/{clientId}")

--- a/smerp/src/main/java/com/domino/smerp/client/ClientRepository.java
+++ b/smerp/src/main/java/com/domino/smerp/client/ClientRepository.java
@@ -1,11 +1,14 @@
 package com.domino.smerp.client;
 
+import com.domino.smerp.user.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ClientRepository extends JpaRepository<Client, Long> {
+public interface ClientRepository extends JpaRepository<Client, Long>,
+    QuerydslPredicateExecutor<Client> {
     Optional<Client> findByCompanyName(String companyName);
     boolean existsByCompanyName(String companyName);
     boolean existsByBusinessNumber(String businessNumber);

--- a/smerp/src/main/java/com/domino/smerp/client/ClientService.java
+++ b/smerp/src/main/java/com/domino/smerp/client/ClientService.java
@@ -11,7 +11,7 @@ public interface ClientService {
 
     void deleteClient(Long clientId);
 
-    List<ClientListResponse> findAllClients();
+    List<ClientListResponse> findAllClients(String companyName, String businessNumber);
 
     ClientResponse findClient(Long clientId);
 


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 회사명으로 검색하거나 사업자 번호로 검색하거나 두 조건을 조합해서 검색하는 기능을 구현했습니다

post맨 예시
GET http://localhost:8080/api/v1/clients?companyName=도미노 => '도미노'를 포함한 회사명 검색
GET http://localhost:8080/api/v1/clients?businessNumber=01 => 사업자 번호가 01 로 시작하는 회사 검색
GET http://localhost:8080/api/v1/clients?companyName=도미노&businessNumber=01 => 회사명이 도미노로 시작하면 사업자번호는 01 로 시작하는 회사 검색
GET http://localhost:8080/api/v1/clients 전체 검색

조건이 간단하기 때문에 쿼리팩토리를 사용하지 않고 BooleanExpression으로 간단하게 구현했습니다.

## ✨ 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
> feature/client/search

## #️⃣ 관련 이슈 (Issue)
- Closes #46 